### PR TITLE
#26 add db-cleaner to clean up old entries

### DIFF
--- a/db-cleaner/Dockerfile
+++ b/db-cleaner/Dockerfile
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.authors="alicef@gentoo.org"
 RUN apk update && apk add --no-cache cronie && rm -rf /var/cache/apk/* && touch /tmp/psql-output
 COPY crontab /etc/cron.d/psql-cron
 COPY slim.psql /slim.psql
-COPY db-connection-env /db-connection-env
+COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT []
+ENTRYPOINT ["/entrypoint.sh"]
 CMD crond && tail -f /tmp/psql-output

--- a/db-cleaner/Dockerfile
+++ b/db-cleaner/Dockerfile
@@ -1,0 +1,10 @@
+from alpine/psql:17.6
+LABEL org.opencontainers.image.authors="alicef@gentoo.org"
+
+RUN apk update && apk add --no-cache cronie && rm -rf /var/cache/apk/* && touch /tmp/psql-output
+COPY crontab /etc/cron.d/psql-cron
+COPY slim.psql /slim.psql
+COPY db-connection-env /db-connection-env
+
+ENTRYPOINT []
+CMD crond && tail -f /tmp/psql-output

--- a/db-cleaner/README.md
+++ b/db-cleaner/README.md
@@ -1,0 +1,3 @@
+# db cleaner
+
+This script is used to clear out old db records and reclaim some disk space. In buildbot, the UI will no longer show the logs for old records. However, the steps will still show up as green or red.

--- a/db-cleaner/crontab
+++ b/db-cleaner/crontab
@@ -1,0 +1,2 @@
+MAILTO=""
+0 3 * * * root . /db-connection-env && psql -f /slim.psql >> /tmp/psql-output 2>&1

--- a/db-cleaner/db-connection-env
+++ b/db-cleaner/db-connection-env
@@ -1,0 +1,5 @@
+export PGHOST=db
+export PGDATABASE=buildbot
+export PGUSER=buildbot
+export PGPASSWORD=change_me
+export PGPORT=5432

--- a/db-cleaner/db-connection-env
+++ b/db-cleaner/db-connection-env
@@ -1,5 +1,0 @@
-export PGHOST=db
-export PGDATABASE=buildbot
-export PGUSER=buildbot
-export PGPASSWORD=change_me
-export PGPORT=5432

--- a/db-cleaner/entrypoint.sh
+++ b/db-cleaner/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+printenv | sed 's/^\(.*\)$/export \1/g' > /db-connection-env
+
+echo "export PGHOST=db" >> /db-connection-env
+echo "export PGPORT=5432" >> /db-connection-env
+echo "export PGUSER=$POSTGRES_USER" >> /db-connection-env
+echo "export PGDATABASE=$POSTGRES_DB" >> /db-connection-env
+echo "export PGPASSWORD=$POSTGRES_PASSWORD" >> /db-connection-env
+
+exec "$@"

--- a/db-cleaner/slim.psql
+++ b/db-cleaner/slim.psql
@@ -1,0 +1,21 @@
+update logchunks
+set
+  compressed = 0,
+  content = '\x00'::bytea,
+  first_line = 0,
+  last_line = 0
+from logs
+join steps on logs.stepid = steps.id
+join builds on steps.buildid = builds.id
+where
+  logchunks.logid = logs.id AND to_timestamp(builds.started_at) < now() - interval '30 days';
+
+update logs
+set
+  num_lines = 0
+from steps
+join builds on steps.buildid = builds.id
+where
+  logs.stepid = steps.id AND to_timestamp(builds.started_at) < now() - interval '30 days';
+
+VACUUM;

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -89,6 +89,12 @@ services:
       - fileserver:/var/www/static
     restart: always
 
+  db-cleaner:
+    build:
+      context: ./db-cleaner
+    networks:
+      - gkernelci-net
+
 volumes:
   db:
   certs:

--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -90,6 +90,7 @@ services:
     restart: always
 
   db-cleaner:
+    env_file: db.env
     build:
       context: ./db-cleaner
     networks:


### PR DESCRIPTION
This PR adds a new entry in docker-compose.yaml which is a crontab entry that will routinely run the SQL cleanup function from issue #26 .

In the web UI , you'll see the following when trying to expand the logs of an entry that has been deleted:

<img width="1341" height="303" alt="2025-09-20-200937_grim" src="https://github.com/user-attachments/assets/89a2c204-9ed9-4bc6-b180-4011bb325dd4" />

But the benefit of doing things this way is that we're preserving the overall steps and whether the steps for that historical entry succeeded or failed.

<img width="1375" height="1605" alt="2025-09-20-201031_grim" src="https://github.com/user-attachments/assets/77d9d305-bcba-498b-b1b8-513e318cf0da" />
