### PR TITLE
remove version tag to be compliant with compose specification

### DIFF
--- a/docker-compose.yml.template
+++ b/docker-compose.yml.template
@@ -1,4 +1,3 @@
-version: '3'
 services:
 
   buildbot:


### PR DESCRIPTION
This is a very small change. I wanted the compose file to be compatible with the Compose Specification. In the world of Docker Compose versioning, they had a version 2 and a version 3, and both were pretty popular, so the team behind them merged the two versions into the Compose Specification, which can be thought of like a version 4 but with some governance around the spec. You can read more about it here.

https://compose-spec.io/

The only incompatibility I found between how we use the compose file and how it is defined in the spec is the existence of the version key, which is deprecated.

with the version tag, you get the following warning:

```
WARN[0000] /home/jesse/code/jesse/GKCI/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

